### PR TITLE
fix: github scopes

### DIFF
--- a/github_trends/web/oauth/github.ex
+++ b/github_trends/web/oauth/github.ex
@@ -16,7 +16,7 @@ defmodule Github do
   end
 
   def authorize_url!(params \\ []) do
-    OAuth2.Client.authorize_url!(client(), scope: "user,public_repo")
+    OAuth2.Client.authorize_url!(client()) 
   end
 
   def get_token!(params \\ [], headers \\ []) do


### PR DESCRIPTION
# Summary
This PR removes too big scopes required for authorization. We don't really use all the data we can get from the user now.