### PR TITLE
chore(elixir): refactor

### DIFF
--- a/github_trends/web/controllers/github_search_controller.ex
+++ b/github_trends/web/controllers/github_search_controller.ex
@@ -53,29 +53,26 @@ defmodule GithubTrends.GithubSearchController do
   end
 
   defp parse_q_parameters(params, q_params_list) do
-    case Map.take(params, q_params_list) do
-      params ->
-        Enum.reduce params, "", fn({key, value}, acc) ->
-          cond do
-            key in ["created", "repos", "followers", "comments"] ->
-              acc <> key <> ":>" <> value <> " "
-            key == "language" ->
-              acc <> key <> ":" <> value <> " "
-          end
-        end
-      _ ->
-        nil
+    params = Map.take(params, q_params_list)
+
+    Enum.reduce params, "", fn({key, value}, acc) ->
+      cond do
+        key in ["created", "repos", "followers", "comments"] ->
+          acc <> key <> ":>" <> value <> " "
+        key == "language" ->
+          acc <> key <> ":" <> value <> " "
+      end
     end
   end
 
   defp parse_parameters(q_params, params) do
     regular_params = Map.take(params, ["sort", "order"])
-    case q_params do
-      nil ->
+
+    if q_params == nil do
         regular_params
-      _ ->
+    else
         Map.put(regular_params, "q", q_params)
-      end
+    end
   end
 
   defp make_request(params, endpoint) do

--- a/github_trends/web/controllers/github_search_controller.ex
+++ b/github_trends/web/controllers/github_search_controller.ex
@@ -82,6 +82,7 @@ defmodule GithubTrends.GithubSearchController do
   defp extract_data(request) do
     case request do
       %{body: [items: items, total_count: _], headers: _} -> items
+
       _ -> []
     end
   end

--- a/github_trends/web/router.ex
+++ b/github_trends/web/router.ex
@@ -42,13 +42,11 @@ defmodule GithubTrends.Router do
   end
 
   defp is_user_logged?(conn, _) do
-    user = get_session(conn, :current_user)
-    case user do
-      nil -> 
+    if get_session(conn, :current_user) == nil do
         conn
         |> redirect(to: "/")
         |> halt
-      _ -> 
+    else
         conn
     end
   end


### PR DESCRIPTION
# Summary
My approach on refactoring elixir code. Some of the patterns in matching clauses would never match so I got rid of them. I did not eliminate all of the compilation warnings, the only left are these:
![image](https://cloud.githubusercontent.com/assets/15965147/26514099/f6e89e28-426f-11e7-9246-44950dca28a9.png)
As far as the two first ones are concerned, I believe it's better to leave these params names to get intution what kind of argument could go in the function invokation. We may not need it now, but if we decide to extend our project knowledge of the kind of arguments passed to the function may be more useful.  
The third one is the plug which we obviously use as a plug.